### PR TITLE
Add Service Bus namespace and update schema version

### DIFF
--- a/AzureBus/azuredeploy.json
+++ b/AzureBus/azuredeploy.json
@@ -1,8 +1,112 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {},
+  "parameters": {
+    "namespaces_AzureBus12_name": {
+      "defaultValue": "AzureBus12",
+      "type": "String"
+    }
+  },
   "variables": {},
-  "resources": [],
-  "outputs": {}
+  "resources": [
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2023-01-01-preview",
+      "name": "[parameters('namespaces_AzureBus12_name')]",
+      "location": "canadacentral",
+      "sku": {
+        "name": "Basic",
+        "tier": "Basic"
+      },
+      "properties": {
+        "geoDataReplication": {
+          "maxReplicationLagDurationInSeconds": 0,
+          "locations": [
+            {
+              "locationName": "canadacentral",
+              "roleType": "Primary"
+            }
+          ]
+        },
+        "premiumMessagingPartitions": 0,
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": false,
+        "zoneRedundant": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/authorizationrules",
+      "apiVersion": "2023-01-01-preview",
+      "name": "[concat(parameters('namespaces_AzureBus12_name'), '/policy')]",
+      "location": "canadacentral",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaces_AzureBus12_name'))]"
+      ],
+      "properties": {
+        "rights": [
+          "Manage",
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/authorizationrules",
+      "apiVersion": "2023-01-01-preview",
+      "name": "[concat(parameters('namespaces_AzureBus12_name'), '/RootManageSharedAccessKey')]",
+      "location": "canadacentral",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaces_AzureBus12_name'))]"
+      ],
+      "properties": {
+        "rights": [
+          "Listen",
+          "Manage",
+          "Send"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/networkrulesets",
+      "apiVersion": "2023-01-01-preview",
+      "name": "[concat(parameters('namespaces_AzureBus12_name'), '/default')]",
+      "location": "canadacentral",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaces_AzureBus12_name'))]"
+      ],
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "defaultAction": "Allow",
+        "virtualNetworkRules": [],
+        "ipRules": [],
+        "trustedServiceAccessEnabled": false
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2023-01-01-preview",
+      "name": "[concat(parameters('namespaces_AzureBus12_name'), '/messagequeue')]",
+      "location": "canadacentral",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('namespaces_AzureBus12_name'))]"
+      ],
+      "properties": {
+        "maxMessageSizeInKilobytes": 256,
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": false,
+        "enableBatchedOperations": true,
+        "duplicateDetectionHistoryTimeWindow": "PT10M",
+        "maxDeliveryCount": 10,
+        "status": "Active",
+        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+        "enablePartitioning": false,
+        "enableExpress": false
+      }
+    }
+  ]
 }

--- a/AzureBus/azuredeploy.parameters.json
+++ b/AzureBus/azuredeploy.parameters.json
@@ -2,5 +2,8 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "namespaces_AzureBus12_name": {
+      "value": null
+    }
   }
 }


### PR DESCRIPTION
Updated azuredeploy.json schema to 2019-04-01. Added new parameter `namespaces_AzureBus12_name` with default value "AzureBus12". Enhanced `resources` and `outputs` sections to define a Service Bus namespace, authorization rules, network rulesets, and a queue. Included properties for geo-replication, premium messaging, TLS, public access, local auth, zone redundancy, and more. Updated azuredeploy.parameters.json with new parameter.